### PR TITLE
Update repository URL for Flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
       - id: debug-statements
-  - repo: https://gitlab.com/pycqa/flake8.git
+  - repo: https://github.com/PyCQA/flake8.git
     rev: 3.9.0
     hooks:
       - id: flake8


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos